### PR TITLE
Update packages to their latest release and the target environment for test projects.

### DIFF
--- a/build/azDevOps/packages-amido-stacks-messaging-aeh.yml
+++ b/build/azDevOps/packages-amido-stacks-messaging-aeh.yml
@@ -30,7 +30,7 @@ variables:
     value: "$(self_pipeline_repo)/scripts"
   # Path specific for this package, change accordingly
   - name: Package.Feed
-    value: "Stacks"
+    value: ""
   - name: Package.Public
     value: true
   - name: Package.nuget_service_connection
@@ -66,8 +66,8 @@ resources:
   repositories:
     - repository: templates
       type: github
-      name: amido/stacks-pipeline-templates
-      ref: refs/tags/v2.0.1
+      name: Ensono/stacks-pipeline-templates
+      ref: refs/heads/feature/cycle4
       # Created when you set up the connection to GitHub from Azure DevOps
       endpoint: amidostacks
   containers:
@@ -81,7 +81,7 @@ stages:
     jobs:
       - job: Validation
         pool:
-          vmImage: "ubuntu-18.04"
+          vmImage: "ubuntu-22.04"
         steps:
           - checkout: self
 
@@ -121,4 +121,4 @@ stages:
               # Secret Config
               cosmosdb_secret: false
               # .NET Core version variables
-              dotnet_core_version: "3.1.x"
+              dotnet_core_version: "6.0.x"

--- a/src/Amido.Stacks.Messaging.Azure.EventHub.Tests/Amido.Stacks.Messaging.Azure.EventHub.Tests.csproj
+++ b/src/Amido.Stacks.Messaging.Azure.EventHub.Tests/Amido.Stacks.Messaging.Azure.EventHub.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -8,17 +8,17 @@
 
  <ItemGroup>
 	<PackageReference Include="Amido.Stacks.DependencyInjection" Version="0.2.21" />
-	<PackageReference Include="Amido.Stacks.Testing" Version="0.2.22" />
+	<PackageReference Include="Amido.Stacks.Testing" Version="0.2.29" />
 	<PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="System.DirectoryServices.Protocols" Version="6.0.2" />
     <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="TestStack.BDDfy" Version="4.3.2" />
-    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit" Version="2.6.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Amido.Stacks.Messaging.Azure.EventHub.Tests/Amido.Stacks.Messaging.Azure.EventHub.Tests.csproj
+++ b/src/Amido.Stacks.Messaging.Azure.EventHub.Tests/Amido.Stacks.Messaging.Azure.EventHub.Tests.csproj
@@ -7,23 +7,23 @@
   </PropertyGroup>
 
  <ItemGroup>
-	<PackageReference Include="Amido.Stacks.DependencyInjection" Version="0.2.19" />
-	<PackageReference Include="Amido.Stacks.Testing" Version="0.2.20" />
-	<PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="Shouldly" Version="4.0.3" />
+	<PackageReference Include="Amido.Stacks.DependencyInjection" Version="0.2.21" />
+	<PackageReference Include="Amido.Stacks.Testing" Version="0.2.22" />
+	<PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="System.DirectoryServices.Protocols" Version="6.0.0" />
     <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="TestStack.BDDfy" Version="4.3.2" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Amido.Stacks.Messaging.Azure.EventHub.Tests/Amido.Stacks.Messaging.Azure.EventHub.Tests.csproj
+++ b/src/Amido.Stacks.Messaging.Azure.EventHub.Tests/Amido.Stacks.Messaging.Azure.EventHub.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
-    <PackageReference Include="System.DirectoryServices.Protocols" Version="6.0.0" />
+    <PackageReference Include="System.DirectoryServices.Protocols" Version="6.0.2" />
     <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="TestStack.BDDfy" Version="4.3.2" />

--- a/src/Amido.Stacks.Messaging.Azure.EventHub.Tests/Serializers/JsonMessageSerializerTests.cs
+++ b/src/Amido.Stacks.Messaging.Azure.EventHub.Tests/Serializers/JsonMessageSerializerTests.cs
@@ -1,6 +1,6 @@
 ﻿using Amido.Stacks.Messaging.Azure.EventHub.Serializers;
 using Amido.Stacks.Messaging.Events;
-using Microsoft.Azure.EventHubs;
+using Azure.Messaging.EventHubs;
 using Newtonsoft.Json;
 using Shouldly;
 using System;

--- a/src/Amido.Stacks.Messaging.Azure.EventHub/Amido.Stacks.Messaging.Azure.EventHub.csproj
+++ b/src/Amido.Stacks.Messaging.Azure.EventHub/Amido.Stacks.Messaging.Azure.EventHub.csproj
@@ -5,12 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amido.Stacks.Application.CQRS.Abstractions" Version="0.2.17" />
-    <PackageReference Include="Amido.Stacks.Configuration" Version="0.2.20" />
-    <PackageReference Include="Amido.Stacks.DependencyInjection" Version="0.2.19" />
-    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.6.0" />
-    <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.6.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="4.1.1" />
+    <PackageReference Include="Amido.Stacks.Application.CQRS.Abstractions" Version="0.2.19" />
+    <PackageReference Include="Amido.Stacks.Configuration" Version="0.2.22" />
+    <PackageReference Include="Amido.Stacks.DependencyInjection" Version="0.2.21" />
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.9.3" />
+    <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.9.3" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="6.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>

--- a/src/Amido.Stacks.Messaging.Azure.EventHub/Amido.Stacks.Messaging.Azure.EventHub.csproj
+++ b/src/Amido.Stacks.Messaging.Azure.EventHub/Amido.Stacks.Messaging.Azure.EventHub.csproj
@@ -5,12 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amido.Stacks.Application.CQRS.Abstractions" Version="0.2.19" />
-    <PackageReference Include="Amido.Stacks.Configuration" Version="0.2.22" />
+    <PackageReference Include="Amido.Stacks.Application.CQRS.Abstractions" Version="0.2.23" />
+    <PackageReference Include="Amido.Stacks.Configuration" Version="0.2.25" />
     <PackageReference Include="Amido.Stacks.DependencyInjection" Version="0.2.21" />
-    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.9.3" />
-    <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.9.3" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="6.0.1" />
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.10.0" />
+    <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.10.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="6.0.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>

--- a/src/Amido.Stacks.Messaging.Azure.EventHub/Serializers/IMessageReader.cs
+++ b/src/Amido.Stacks.Messaging.Azure.EventHub/Serializers/IMessageReader.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Azure.EventHubs;
+﻿using Azure.Messaging.EventHubs;
 
 namespace Amido.Stacks.Messaging.Azure.EventHub.Serializers
 {

--- a/src/Amido.Stacks.Messaging.Azure.EventHub/Serializers/JsonMessageSerializer.cs
+++ b/src/Amido.Stacks.Messaging.Azure.EventHub/Serializers/JsonMessageSerializer.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Azure.EventHubs;
+﻿using Azure.Messaging.EventHubs;
 using Newtonsoft.Json;
 using System.Text;
 
@@ -8,7 +8,7 @@ namespace Amido.Stacks.Messaging.Azure.EventHub.Serializers
     {
         public T Read<T>(EventData eventData)
         {
-            var jsonBody = Encoding.UTF8.GetString(eventData.Body.Array);
+            var jsonBody = Encoding.UTF8.GetString(eventData.Body.ToArray());
             return JsonConvert.DeserializeObject<T>(jsonBody);
         }
     }

--- a/src/Amido.Stacks.Messaging.Events/Amido.Stacks.Messaging.Events.csproj
+++ b/src/Amido.Stacks.Messaging.Events/Amido.Stacks.Messaging.Events.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amido.Stacks.Application.CQRS.Abstractions" Version="0.2.17" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Amido.Stacks.Application.CQRS.Abstractions" Version="0.2.19" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   
 </Project>

--- a/src/Amido.Stacks.Messaging.Events/Amido.Stacks.Messaging.Events.csproj
+++ b/src/Amido.Stacks.Messaging.Events/Amido.Stacks.Messaging.Events.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amido.Stacks.Application.CQRS.Abstractions" Version="0.2.19" />
+    <PackageReference Include="Amido.Stacks.Application.CQRS.Abstractions" Version="0.2.23" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   


### PR DESCRIPTION
### Update packages to their latest release.

#### 📲 What

Updating packages to their latest releases.  The deprecated Microsoft.Azure.EventHubs package has been replaced with the new Azure.Messaging.EventHubs package, which has involved simple namespace changes.
The target framework for the test project has also been updated to 'net6' from 'netcoreapp3.1' because netcoreapp3.1 is no longer supported. The Azure DevOps build file has also been adjusted for a .NET 6 build.

#### 🤔 Why

Package updates have been requested for .NET and Java Stacks as part of the latest Stacks cycle.

#### 🛠 How

Simple package updates in both csproj files.

#### 👀 Evidence

See csproj file changes in the 'Files Changed' tab for package updates.

#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
